### PR TITLE
fix: release automation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .release-please-config.json

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -3,6 +3,8 @@
     ".": {
       "release-type": "simple",
       "package-name": "netlius",
+      "include-component-in-tag": false,
+      "include-v-in-tag": false,
       "extra-files": [
         {
           "type": "regex",


### PR DESCRIPTION
This pull request updates the release automation configuration to simplify the release tagging and ensure compatibility with the latest GitHub Actions usage. The changes mainly focus on the release workflow and tagging conventions.

**Release workflow configuration:**

* Updated the GitHub Actions step to use `googleapis/release-please-action@v4` instead of `google-github-actions/release-please-action@v4` in `.github/workflows/release-please.yml`

**Release tagging conventions:**

* Modified `.release-please-config.json` to set `"include-component-in-tag": false` and `"include-v-in-tag": false`, ensuring that release tags do not include the component name or a leading `v`.