### PR TITLE
fix: update copyright year in license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Camden
+Copyright (c) 2020-2025 Camden
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request updates the copyright year range in the `LICENSE` file to reflect continued ownership through 2025.

* Updated copyright year range from "2020" to "2020-2025" in `LICENSE` to ensure legal coverage for recent and future contributions.